### PR TITLE
Json output wrong type

### DIFF
--- a/TestVersionedObject/EdgeReificationTests.cs
+++ b/TestVersionedObject/EdgeReificationTests.cs
@@ -76,7 +76,7 @@ namespace VersionedObject.Tests
                         new IRIReference(new string($"http://rdf.equinor.com/ontology/sor#Row{i}")),
                         new JObject()
                         {
-                            ["@type"] = new JArray() {"http://rdf.equinor.com/ontology/mel#MelRow"},
+                            ["@type"] = new JArray() { "http://rdf.equinor.com/ontology/mel#MelRow" },
                             ["rdfs:label"] = "An empty MEL Row",
                         }
                     )
@@ -88,7 +88,7 @@ namespace VersionedObject.Tests
         public static readonly JObject LargeAspectJsonLd = new()
         {
             ["@graph"] = new JArray(LargeAspectVersionedGraph.Select(o => o.ToJObject())),
-            
+
             ["@context"] = new JObject()
             {
                 ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",

--- a/TestVersionedObject/EdgeReificationTests.cs
+++ b/TestVersionedObject/EdgeReificationTests.cs
@@ -44,7 +44,7 @@ namespace VersionedObject.Tests
             }
         };
 
-        public static readonly int test_size = 1;
+        public static readonly int test_size = 10;
 
         public static readonly JObject LargeInputJsonLd = new()
         {
@@ -137,47 +137,11 @@ namespace VersionedObject.Tests
         }
 
         [Fact]
-        public void TestFullEdgeReifierPerformance()
-        {
-            LargeInputJsonLd.HandleGraphCompleteUpdate(LargeAspectJsonLd);
-        }
-
-        [Fact]
         public void TestGetPersistentIrirs()
         {
             var persistent = GetAllPersistentIris(LargeInputJsonLd, LargeAspectJsonLd);
             Assert.NotNull(persistent);
             Assert.Equal(test_size, persistent.Count());
-        }
-
-        [Fact]
-        public void TestEdgeReifierPerformance()
-        {
-            var edged_list = LargeInputJsonLd.GetInputGraphAsEntities().ToImmutableList();
-
-            var persistentEntities = LargeAspectGraph.Select(o => o.PersistentIRI).ToImmutableList();
-            var existing_list = LargeAspectVersionedGraph.ToImmutableList();
-            var refs2 = edged_list.ReifyAllEdges(persistentEntities).ToImmutableList();
-            var reified_json = from j in refs2 select j.ToJsonldJObject();
-            var updateList = refs2.MakeUpdateList(existing_list).ToImmutableList();
-            var reified_update = from j in updateList select j.ToJObject();
-            Assert.Equal(test_size, updateList.Count());
-            //var map = updateList.Union(existing_list).MakePersistentIriMap();
-            var map = ImmutableDictionary.CreateRange(
-                    from obj in existing_list
-                    select new KeyValuePair<IRIReference, VersionedIRIReference>(obj.GetPersistentIRI(),
-                        obj.VersionedIri)
-                )
-                .RemoveRange(updateList.Select(o => o.GetPersistentIRI()))
-                .AddRange(
-                    from obj in updateList
-                    select new KeyValuePair<IRIReference, VersionedIRIReference>(obj.GetPersistentIRI(),
-                        obj.VersionedIri)
-                );
-            var versionedUpdate = updateList.UpdateEdgeIris(map).ToImmutableList();
-            var versioned_update_json = from j in versionedUpdate select j.ToJObject();
-            var deleteList = EntityGraphComparer.MakeDeleteList(refs2, existing_list).ToImmutableList();
-            Assert.Empty(deleteList);
         }
 
     }

--- a/TestVersionedObject/EdgeReificationTests.cs
+++ b/TestVersionedObject/EdgeReificationTests.cs
@@ -53,7 +53,7 @@ namespace VersionedObject.Tests
                 Enumerable.Range(1, test_size)
                     .Select(i => new JObject()
                         {
-                            ["@id"] = $"sor:Row{i}",
+                            ["@id"] = new JValue($"sor:Row{i}"),
                             ["@type"] = "MelRow",
                             ["rdfs:label"] = $"Empty MEL Row {i}"
                         }
@@ -73,7 +73,7 @@ namespace VersionedObject.Tests
             Enumerable.Range(1, test_size)
                 .Select(i =>
                     new PersistentObjectData(
-                        new IRIReference($"http://rdf.equinor.com/ontology/sor#Row{i}"),
+                        new IRIReference(new string($"http://rdf.equinor.com/ontology/sor#Row{i}")),
                         new JObject()
                         {
                             ["@type"] = new JArray() {"http://rdf.equinor.com/ontology/mel#MelRow"},
@@ -87,10 +87,8 @@ namespace VersionedObject.Tests
 
         public static readonly JObject LargeAspectJsonLd = new()
         {
-            ["@graph"] = new JArray()
-            {
-                LargeAspectVersionedGraph.Select(o => o.ToJObject())
-            },
+            ["@graph"] = new JArray(LargeAspectVersionedGraph.Select(o => o.ToJObject())),
+            
             ["@context"] = new JObject()
             {
                 ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",

--- a/TestVersionedObject/VersionedObjectTests.cs
+++ b/TestVersionedObject/VersionedObjectTests.cs
@@ -335,7 +335,7 @@ namespace VersionedObject.Tests
             Assert.NotNull(expanded);
             var second = expanded.RemoveContext();
             Assert.Equal(new IRIReference("http://rdf.equinor.com/ontology/sor#Row2"), new IRIReference(second.GetJsonLdGraph().Values<JObject>().First().GetIRIReference()));
-            
+
             var vobject = JObject.Parse(@"{
                 ""@graph"": [
                 {

--- a/TestVersionedObject/VersionedObjectTests.cs
+++ b/TestVersionedObject/VersionedObjectTests.cs
@@ -335,8 +335,29 @@ namespace VersionedObject.Tests
             Assert.NotNull(expanded);
             var second = expanded.RemoveContext();
             Assert.Equal(new IRIReference("http://rdf.equinor.com/ontology/sor#Row2"), new IRIReference(second.GetJsonLdGraph().Values<JObject>().First().GetIRIReference()));
-        }
+            
+            var vobject = JObject.Parse(@"{
+                ""@graph"": [
+                {
+                    ""@type"": [
+                    ""http://rdf.equinor.com/ontology/mel#MelRow""
+                        ],
+                    ""rdfs:label"": ""An empty MEL Row"",
+                    ""@id"": ""http://rdf.equinor.com/ontology/sor#Row1/version/22310441759822761165/1659612640"",
+                    ""http://www.w3.org/ns/prov#wasDerivedFrom"": ""http://www.w3.org/1999/02/22-rdf-syntax-ns#nil""
+                }
+                ],
+                ""@context"": {
+                    ""rdfs"": ""http://www.w3.org/2000/01/rdf-schema#"",
+                    ""sor"": ""http://rdf.equinor.com/ontology/sor#"",
+                    ""imf"": ""http://imf.imfid.org/ontology/imf#"",
+                    ""@version"": ""1.1""
+                }
+            }");
+            var flat = vobject.RemoveContext();
+            Assert.NotNull(flat);
 
+        }
 
         [Fact()]
         public void GetAllIdsTest()

--- a/VersionedObject/IRIReference.cs
+++ b/VersionedObject/IRIReference.cs
@@ -37,7 +37,7 @@ public class IRIReference : IEquatable<IRIReference>
 
     public override string ToString() => uri.ToString();
 
-    public JValue ToJValue() => new(uri);
+    public JValue ToJValue() => new(ToString());
     public JValue ToJToken() => ToJValue();
 
 

--- a/VersionedObject/VersionedObject.csproj
+++ b/VersionedObject/VersionedObject.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="dotNetRDF" Version="2.7.4" />
+    <PackageReference Include="dotNetRDF" Version="2.7.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Data.HashFunction.CRC" Version="2.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Fixes a bug in IRIReference.ToJValue. This originally wrapped the "@id" in a Uri, and not a string, which is necessary when using the JObject directly. 

Start review by looking at the change in IRIReference, then perhaps running the new tests. 

In addition there is: 
- an update of the DotNetRDF library to new version
- Removed duplicate code/initialiation in existing test in EdgeReificationTests