### PR TITLE
Correct creation of map from persistent to versioned IRIs

### DIFF
--- a/TestVersionedObject/EdgeReificationTests.cs
+++ b/TestVersionedObject/EdgeReificationTests.cs
@@ -129,7 +129,6 @@ namespace VersionedObject.Tests
             var updateList = refs2.MakeUpdateList(existing_list);
             var reified_update = from j in updateList select j.ToJObject();
             Assert.Equal(2, updateList.Count());
-            //var map =  updateList.Union(existing_list).MakePersistentIriMap();
             var map = existing_list.MakeUpdatedPersistentIriMap(updateList);
             var versionedUpdate = updateList.UpdateEdgeIris(map);
             var versioned_update_json = from j in versionedUpdate select j.ToJObject();

--- a/TestVersionedObject/EdgeReificationTests.cs
+++ b/TestVersionedObject/EdgeReificationTests.cs
@@ -129,7 +129,8 @@ namespace VersionedObject.Tests
             var updateList = refs2.MakeUpdateList(existing_list);
             var reified_update = from j in updateList select j.ToJObject();
             Assert.Equal(2, updateList.Count());
-            var map = updateList.Union(existing_list).MakePersistentIriMap();
+            //var map =  updateList.Union(existing_list).MakePersistentIriMap();
+            var map = existing_list.MakeUpdatedPersistentIriMap(updateList);
             var versionedUpdate = updateList.UpdateEdgeIris(map);
             var versioned_update_json = from j in versionedUpdate select j.ToJObject();
             var deleteList = EntityGraphComparer.MakeDeleteList(refs2, existing_list);
@@ -142,6 +143,12 @@ namespace VersionedObject.Tests
             var persistent = GetAllPersistentIris(LargeInputJsonLd, LargeAspectJsonLd);
             Assert.NotNull(persistent);
             Assert.Equal(test_size, persistent.Count());
+        }
+
+        [Fact]
+        public void TestFullEdgeReifier()
+        {
+            LargeInputJsonLd.HandleGraphCompleteUpdate(LargeAspectJsonLd);
         }
 
     }

--- a/VersionedObject/EntityGraphComparer.cs
+++ b/VersionedObject/EntityGraphComparer.cs
@@ -47,7 +47,7 @@ namespace VersionedObject
             var reifiedInput = inputList.ReifyAllEdges(persistentEntities);
             var existingList = existing.GetExistingGraphAsEntities(persistentEntities);
             var updateList = reifiedInput.MakeUpdateList(existingList);
-            var versionedIriMap = updateList.Union(existingList).MakePersistentIriMap();
+            var versionedIriMap = existingList.MakeUpdatedPersistentIriMap(updateList);
             var versionedUpdateList = updateList.UpdateEdgeIris(versionedIriMap);
             var deleteList = MakeDeleteList(reifiedInput, existingList);
             return CreateUpdateJObject(versionedUpdateList, deleteList);
@@ -161,14 +161,27 @@ namespace VersionedObject
                 .Select(s => s.id ?? throw new InvalidJsonLdException($"No @id element found in JObject {s.obj}"))
                 .Select(s => new Uri(s));
 
+        public static ImmutableDictionary<IRIReference, VersionedIRIReference> MakeUpdatedPersistentIriMap(
+            this IEnumerable<VersionedObject> existingObjects, IEnumerable<VersionedObject> updateObjects) =>
+            existingObjects.MakePersistentIriMap()
+                .UpdateIriDictionary(updateObjects.MakePersistentIriMap());
+
+
+        ///<summary>
+        /// Makes an updated list of versioned objects, removing those that are being updated
+        /// </summary>
+        internal static ImmutableDictionary<IRIReference, VersionedIRIReference> UpdateIriDictionary(
+            this ImmutableDictionary<IRIReference, VersionedIRIReference> existingDict,
+            ImmutableDictionary<IRIReference, VersionedIRIReference> updateDict) =>
+            updateDict.Aggregate(existingDict, (dict, u) => dict.SetItem(u.Key, u.Value))
+                .ToImmutableDictionary();
+
         /// <summary>
         /// Called on list of versioned objects to get a mapping from persistent to versioned IRIs
         /// Similar to a HEAD mapping in aspect api
         /// </summary>
-        /// <param name="input"></param>
-        /// <param name="existing"></param>
         /// <returns></returns>
-        public static ImmutableDictionary<IRIReference, VersionedIRIReference> MakePersistentIriMap(
+        internal static ImmutableDictionary<IRIReference, VersionedIRIReference> MakePersistentIriMap(
             this IEnumerable<VersionedObject> objectList) =>
             ImmutableDictionary.CreateRange(
                 from obj in objectList

--- a/VersionedObject/EntityGraphComparer.cs
+++ b/VersionedObject/EntityGraphComparer.cs
@@ -181,7 +181,7 @@ namespace VersionedObject
         /// Similar to a HEAD mapping in aspect api
         /// </summary>
         /// <returns></returns>
-        internal static ImmutableDictionary<IRIReference, VersionedIRIReference> MakePersistentIriMap(
+        public static ImmutableDictionary<IRIReference, VersionedIRIReference> MakePersistentIriMap(
             this IEnumerable<VersionedObject> objectList) =>
             ImmutableDictionary.CreateRange(
                 from obj in objectList


### PR DESCRIPTION
Motivation: Fixes issue #35. The code to create a map from persistent to versioned IRIs crashed because both the old and the new versioned IRI was given to it. This new code avoids that, hopefully without too bad performance. 


Start the review with checking out the new methods in EntityGraphComparer. 

The new tests are simple, and look like an integration test, since the relevant calls are in the top-level method EntityGraphComparer.HandleGraphUpdate