### PR TITLE
Speed improvement

### DIFF
--- a/CLI/PerformanceTests.csproj
+++ b/CLI/PerformanceTests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\VersionedObject\VersionedObject.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/CLI/Program.cs
+++ b/CLI/Program.cs
@@ -73,7 +73,7 @@ namespace VersionedObject.CLI
                         new IRIReference(new string($"http://rdf.equinor.com/ontology/sor#Row{i}")),
                         new JObject()
                         {
-                            ["@type"] = new JArray() {"http://rdf.equinor.com/ontology/mel#MelRow"},
+                            ["@type"] = new JArray() { "http://rdf.equinor.com/ontology/mel#MelRow" },
                             ["rdfs:label"] = "An empty MEL Row",
                         }
                     )

--- a/CLI/Program.cs
+++ b/CLI/Program.cs
@@ -1,0 +1,108 @@
+﻿using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using AngleSharp.Dom;
+using VDS.RDF.Query.Algebra;
+using static VersionedObject.EntityGraphComparer;
+using static VersionedObject.JsonLdHelper;
+
+
+namespace VersionedObject.CLI
+{
+    public class Data
+    {
+
+        public static readonly JObject InputEdgeJsonLd = new()
+        {
+            ["@graph"] = new JArray()
+            {
+                new JObject()
+                {
+                    ["@id"] = "sor:Row1",
+                    ["@type"] = "MelRow",
+                    ["rdfs:label"] = "An empty MEL Row",
+                    ["imf:hasChild"] = "http://rdf.equinor.com/ontology/sor#Row2"
+                },
+                new JObject()
+                {
+                    ["@id"] = "sor:Row2",
+                    ["@type"] = "MelRow",
+                    ["rdfs:label"] = "The second MEL Row"
+                }
+            },
+            ["@context"] = new JObject()
+            {
+                ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",
+                ["@vocab"] = "http://rdf.equinor.com/ontology/mel#",
+                ["sor"] = "http://rdf.equinor.com/ontology/sor#",
+                ["imf"] = "http://imf.imfid.org/ontology/imf#",
+                ["@version"] = "1.1"
+            }
+        };
+
+        public static readonly int test_size = 2000;
+
+        public static readonly JObject LargeInputJsonLd = new()
+        {
+            ["@graph"] = new JArray()
+            {
+                Enumerable.Range(1, test_size)
+                    .Select(i => new JObject()
+                        {
+                            ["@id"] = new JValue($"sor:Row{i}"),
+                            ["@type"] = "MelRow",
+                            ["rdfs:label"] = $"Empty MEL Row {i}"
+                        }
+                    )
+            },
+            ["@context"] = new JObject()
+            {
+                ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",
+                ["@vocab"] = "http://rdf.equinor.com/ontology/mel#",
+                ["sor"] = "http://rdf.equinor.com/ontology/sor#",
+                ["imf"] = "http://imf.imfid.org/ontology/imf#",
+                ["@version"] = "1.1"
+            }
+        };
+
+        public static readonly IEnumerable<PersistentObjectData> LargeAspectGraph =
+            Enumerable.Range(1, test_size)
+                .Select(i =>
+                    new PersistentObjectData(
+                        new IRIReference(new string($"http://rdf.equinor.com/ontology/sor#Row{i}")),
+                        new JObject()
+                        {
+                            ["@type"] = new JArray() {"http://rdf.equinor.com/ontology/mel#MelRow"},
+                            ["rdfs:label"] = "An empty MEL Row",
+                        }
+                    )
+                );
+
+        public static readonly IEnumerable<VersionedObject> LargeAspectVersionedGraph =
+            LargeAspectGraph.Select(o => new VersionedObject(o));
+
+        public static readonly JObject LargeAspectJsonLd = new()
+        {
+            ["@graph"] = new JArray(LargeAspectVersionedGraph.Select(o => o.ToJObject())),
+
+            ["@context"] = new JObject()
+            {
+                ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",
+                ["sor"] = "http://rdf.equinor.com/ontology/sor#",
+                ["imf"] = "http://imf.imfid.org/ontology/imf#",
+                ["@version"] = "1.1"
+            }
+        };
+
+        public static void Main()
+        {
+            var start_time = DateTime.Now;
+            var update = Data.LargeInputJsonLd.HandleGraphCompleteUpdate(Data.LargeAspectJsonLd);
+            var used_time = DateTime.Now - start_time;
+            System.Console.WriteLine($"Objects: {test_size}. Time: {used_time}");
+        }
+
+    }
+
+}

--- a/CLI/Program.cs
+++ b/CLI/Program.cs
@@ -41,7 +41,7 @@ namespace VersionedObject.CLI
             }
         };
 
-        public static readonly int test_size = 3000;
+        public static readonly int test_size = 10000;
 
         public static readonly JObject LargeInputJsonLd = new()
         {

--- a/CLI/Program.cs
+++ b/CLI/Program.cs
@@ -41,7 +41,7 @@ namespace VersionedObject.CLI
             }
         };
 
-        public static readonly int test_size = 2000;
+        public static readonly int test_size = 3000;
 
         public static readonly JObject LargeInputJsonLd = new()
         {

--- a/TestVersionedObject/EdgeReificationTests.cs
+++ b/TestVersionedObject/EdgeReificationTests.cs
@@ -121,7 +121,7 @@ namespace VersionedObject.Tests
         {
             var edged_list = InputEdgeJsonLd.GetInputGraphAsEntities();
 
-            var persistentEntities = GetAllPersistentIris(InputEdgeJsonLd, VersionedObjectTests.aspect_jsonld);
+            var persistentEntities = GetAllPersistentIris(InputEdgeJsonLd, VersionedObjectTests.aspect_jsonld).ToImmutableHashSet();
             var existingJObject = VersionedObjectTests.aspect_jsonld.ToString();
             var existing_list = VersionedObjectTests.aspect_jsonld.GetExistingGraphAsEntities(persistentEntities);
             var refs2 = edged_list.ReifyAllEdges(persistentEntities);

--- a/TestVersionedObject/EdgeReificationTests.cs
+++ b/TestVersionedObject/EdgeReificationTests.cs
@@ -44,7 +44,7 @@ namespace VersionedObject.Tests
             }
         };
 
-        public static readonly int test_size = 10;
+        public static readonly int test_size = 10000;
 
         public static readonly JObject LargeInputJsonLd = new()
         {

--- a/TestVersionedObject/EdgeReificationTests.cs
+++ b/TestVersionedObject/EdgeReificationTests.cs
@@ -44,7 +44,7 @@ namespace VersionedObject.Tests
             }
         };
 
-        public static readonly int test_size = 10000;
+        public static readonly int test_size = 100;
 
         public static readonly JObject LargeInputJsonLd = new()
         {

--- a/TestVersionedObject/VersionedObjectTests.cs
+++ b/TestVersionedObject/VersionedObjectTests.cs
@@ -442,8 +442,7 @@ namespace VersionedObject.Tests
         public void TestRemoveVersionFromUris()
         {
             var urilist = ImmutableHashSet<IRIReference>.Empty.Add(new("http://rdf.equinor.com/ontology/sor#Row1"));
-            var removed_versions =
-                JsonLdHelper.RemoveVersionFromObject(urilist)(aspect_persistent_jsonld.RemoveContext());
+            var removed_versions = aspect_persistent_jsonld.RemoveContext().RemoveVersionsFromIris(urilist);
             Assert.Equal("http://rdf.equinor.com/ontology/sor#Row1", removed_versions["@id"]);
         }
 

--- a/TestVersionedObject/VersionedObjectTests.cs
+++ b/TestVersionedObject/VersionedObjectTests.cs
@@ -158,7 +158,7 @@ namespace VersionedObject.Tests
             Assert.True(aspectFirst.Equals(simpleFirst),
                 "Equality test on input and aspect jsonld failed");
             Assert.False(
-                aspect_jsonld.GetExistingGraphAsEntities(ImmutableHashSet<IRIReference>.Empty.Add(new IRIReference("http://rdf.equinor.com/ontology/sor#Row1") )).First().Object
+                aspect_jsonld.GetExistingGraphAsEntities(ImmutableHashSet<IRIReference>.Empty.Add(new IRIReference("http://rdf.equinor.com/ontology/sor#Row1"))).First().Object
                 .Equals(DifferentJsonLd.GetInputGraphAsEntities().First()), "Equality test on input and aspect jsonld failed");
         }
 
@@ -166,7 +166,7 @@ namespace VersionedObject.Tests
         public void RdfHashTest()
         {
             var aspectFirst = aspect_jsonld
-                .GetExistingGraphAsEntities(ImmutableHashSet<IRIReference>.Empty.Add(new IRIReference("http://rdf.equinor.com/ontology/sor#Row1") ))
+                .GetExistingGraphAsEntities(ImmutableHashSet<IRIReference>.Empty.Add(new IRIReference("http://rdf.equinor.com/ontology/sor#Row1")))
                 .First();
             var aspectHashCode = string.Join("", aspectFirst.Object.GetHash());
             Assert.Equal(aspectHashCode, aspectFirst.VersionedIri.VersionHash);
@@ -225,7 +225,7 @@ namespace VersionedObject.Tests
         [Fact()]
         public void MakeUpdateListTest()
         {
-            var updatelist = DifferentJsonLd.GetInputGraphAsEntities().MakeUpdateList(aspect_jsonld.GetExistingGraphAsEntities(ImmutableHashSet<IRIReference>.Empty.Add(new IRIReference("http://rdf.equinor.com/ontology/sor#Row1") )));
+            var updatelist = DifferentJsonLd.GetInputGraphAsEntities().MakeUpdateList(aspect_jsonld.GetExistingGraphAsEntities(ImmutableHashSet<IRIReference>.Empty.Add(new IRIReference("http://rdf.equinor.com/ontology/sor#Row1"))));
             Assert.True(updatelist.Any());
             Assert.Single(updatelist);
             Assert.Equal(DifferentJsonLd.GetInputGraphAsEntities().First().PersistentIRI, updatelist.First().GetPersistentIRI());
@@ -289,7 +289,7 @@ namespace VersionedObject.Tests
         [Fact()]
         public void MakeNoDeleteListTest()
         {
-            var deletelist = SimpleJsonLd.GetInputGraphAsEntities().MakeDeleteList(aspect_jsonld.GetExistingGraphAsEntities(ImmutableHashSet<IRIReference>.Empty.Add(new IRIReference("http://rdf.equinor.com/ontology/sor#Row1") )));
+            var deletelist = SimpleJsonLd.GetInputGraphAsEntities().MakeDeleteList(aspect_jsonld.GetExistingGraphAsEntities(ImmutableHashSet<IRIReference>.Empty.Add(new IRIReference("http://rdf.equinor.com/ontology/sor#Row1"))));
             Assert.NotNull(deletelist);
             Assert.False(deletelist.Any());
         }
@@ -441,7 +441,7 @@ namespace VersionedObject.Tests
         [Fact]
         public void TestRemoveVersionFromUris()
         {
-            var urilist = ImmutableHashSet<IRIReference>.Empty.Add(new("http://rdf.equinor.com/ontology/sor#Row1") );
+            var urilist = ImmutableHashSet<IRIReference>.Empty.Add(new("http://rdf.equinor.com/ontology/sor#Row1"));
             var removed_versions =
                 JsonLdHelper.RemoveVersionFromObject(urilist)(aspect_persistent_jsonld.RemoveContext());
             Assert.Equal("http://rdf.equinor.com/ontology/sor#Row1", removed_versions["@id"]);

--- a/TestVersionedObject/VersionedObjectTests.cs
+++ b/TestVersionedObject/VersionedObjectTests.cs
@@ -1,5 +1,6 @@
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Xunit;
 using static VersionedObject.EntityGraphComparer;
@@ -137,7 +138,7 @@ namespace VersionedObject.Tests
         {
             Assert.True(
                 SimpleJsonLd.GetInputGraphAsEntities().First().Equals(
-                    aspect_jsonld.GetExistingGraphAsEntities(new List<IRIReference>()).First().Object),
+                    aspect_jsonld.GetExistingGraphAsEntities(ImmutableHashSet.Create<IRIReference>()).First().Object),
                 "Equality test on input and aspect jsonld failed");
             Assert.False(
                 SimpleJsonLd.GetInputGraphAsEntities().First()
@@ -148,7 +149,7 @@ namespace VersionedObject.Tests
         public void RdfEqualsTest()
         {
             var aspectFirst = aspect_jsonld
-                .GetExistingGraphAsEntities(new[] { new IRIReference("http://rdf.equinor.com/ontology/sor#Row1") })
+                .GetExistingGraphAsEntities(ImmutableHashSet<IRIReference>.Empty.Add(new IRIReference("http://rdf.equinor.com/ontology/sor#Row1")))
                 .First().Object;
             var simpleFirst = SimpleJsonLd.GetInputGraphAsEntities().First();
             var aspectHashCode = aspectFirst.GetHash();
@@ -157,7 +158,7 @@ namespace VersionedObject.Tests
             Assert.True(aspectFirst.Equals(simpleFirst),
                 "Equality test on input and aspect jsonld failed");
             Assert.False(
-                aspect_jsonld.GetExistingGraphAsEntities(new[] { new IRIReference("http://rdf.equinor.com/ontology/sor#Row1") }).First().Object
+                aspect_jsonld.GetExistingGraphAsEntities(ImmutableHashSet<IRIReference>.Empty.Add(new IRIReference("http://rdf.equinor.com/ontology/sor#Row1") )).First().Object
                 .Equals(DifferentJsonLd.GetInputGraphAsEntities().First()), "Equality test on input and aspect jsonld failed");
         }
 
@@ -165,7 +166,7 @@ namespace VersionedObject.Tests
         public void RdfHashTest()
         {
             var aspectFirst = aspect_jsonld
-                .GetExistingGraphAsEntities(new[] { new IRIReference("http://rdf.equinor.com/ontology/sor#Row1") })
+                .GetExistingGraphAsEntities(ImmutableHashSet<IRIReference>.Empty.Add(new IRIReference("http://rdf.equinor.com/ontology/sor#Row1") ))
                 .First();
             var aspectHashCode = string.Join("", aspectFirst.Object.GetHash());
             Assert.Equal(aspectHashCode, aspectFirst.VersionedIri.VersionHash);
@@ -224,7 +225,7 @@ namespace VersionedObject.Tests
         [Fact()]
         public void MakeUpdateListTest()
         {
-            var updatelist = DifferentJsonLd.GetInputGraphAsEntities().MakeUpdateList(aspect_jsonld.GetExistingGraphAsEntities(new[] { new IRIReference("http://rdf.equinor.com/ontology/sor#Row1") }));
+            var updatelist = DifferentJsonLd.GetInputGraphAsEntities().MakeUpdateList(aspect_jsonld.GetExistingGraphAsEntities(ImmutableHashSet<IRIReference>.Empty.Add(new IRIReference("http://rdf.equinor.com/ontology/sor#Row1") )));
             Assert.True(updatelist.Any());
             Assert.Single(updatelist);
             Assert.Equal(DifferentJsonLd.GetInputGraphAsEntities().First().PersistentIRI, updatelist.First().GetPersistentIRI());
@@ -259,8 +260,8 @@ namespace VersionedObject.Tests
         public void MakeNoUpdateListTest()
         {
             var input_entities = SimpleJsonLd.GetInputGraphAsEntities();
-            var existing_entities = aspect_jsonld.GetExistingGraphAsEntities(new[]
-                {new IRIReference("http://rdf.equinor.com/ontology/sor#Row1")});
+            var existing_entities = aspect_jsonld.GetExistingGraphAsEntities(ImmutableHashSet<IRIReference>.Empty
+                .Add(new IRIReference("http://rdf.equinor.com/ontology/sor#Row1")));
             var updatelist = input_entities.MakeUpdateList(existing_entities);
             Assert.NotNull(updatelist);
             Assert.False(updatelist.Any());
@@ -271,7 +272,9 @@ namespace VersionedObject.Tests
         {
             var simple_object = SimpleJsonLd.RemoveContext();
             var simple_entity = SimpleJsonLd.GetInputGraphAsEntities().First();
-            var aspect_entity = aspect_jsonld.GetExistingGraphAsEntities(new[] { new IRIReference("http://rdf.equinor.com/ontology/sor#Row1") }).First();
+            var aspect_list = aspect_jsonld.GetExistingGraphAsEntities(
+                ImmutableHashSet<IRIReference>.Empty.Add(new IRIReference("http://rdf.equinor.com/ontology/sor#Row1"))).ToImmutableList();
+            var aspect_entity = aspect_list.First();
             Assert.Equal(simple_entity, aspect_entity.Object);
         }
 
@@ -286,7 +289,7 @@ namespace VersionedObject.Tests
         [Fact()]
         public void MakeNoDeleteListTest()
         {
-            var deletelist = SimpleJsonLd.GetInputGraphAsEntities().MakeDeleteList(aspect_jsonld.GetExistingGraphAsEntities(new[] { new IRIReference("http://rdf.equinor.com/ontology/sor#Row1") }));
+            var deletelist = SimpleJsonLd.GetInputGraphAsEntities().MakeDeleteList(aspect_jsonld.GetExistingGraphAsEntities(ImmutableHashSet<IRIReference>.Empty.Add(new IRIReference("http://rdf.equinor.com/ontology/sor#Row1") )));
             Assert.NotNull(deletelist);
             Assert.False(deletelist.Any());
         }
@@ -305,7 +308,7 @@ namespace VersionedObject.Tests
         [Fact()]
         public void MakeExistingGrahEntitiesTest()
         {
-            var persistentIris = GetAllPersistentIris(Row2JsonLd, expanded_jsonld);
+            var persistentIris = GetAllPersistentIris(Row2JsonLd, expanded_jsonld).ToImmutableHashSet();
             var existing = expanded_jsonld.GetExistingGraphAsEntities(persistentIris);
             Assert.NotNull(existing);
             Assert.Single(existing);
@@ -318,7 +321,7 @@ namespace VersionedObject.Tests
         public void MakeDeleteListTest()
         {
             var input = Row2JsonLd.GetInputGraphAsEntities();
-            var persistentIris = EntityGraphComparer.GetAllPersistentIris(Row2JsonLd, expanded_jsonld);
+            var persistentIris = EntityGraphComparer.GetAllPersistentIris(Row2JsonLd, expanded_jsonld).ToImmutableHashSet();
             var existing = expanded_jsonld.GetExistingGraphAsEntities(persistentIris);
 
             var deletelist = input.MakeDeleteList(existing);
@@ -438,8 +441,9 @@ namespace VersionedObject.Tests
         [Fact]
         public void TestRemoveVersionFromUris()
         {
-            var urilist = new List<IRIReference>() { new("http://rdf.equinor.com/ontology/sor#Row1") };
-            var removed_versions = aspect_persistent_jsonld.RemoveContext().RemoveVersionFromUris(urilist);
+            var urilist = ImmutableHashSet<IRIReference>.Empty.Add(new("http://rdf.equinor.com/ontology/sor#Row1") );
+            var removed_versions =
+                JsonLdHelper.RemoveVersionFromObject(urilist)(aspect_persistent_jsonld.RemoveContext());
             Assert.Equal("http://rdf.equinor.com/ontology/sor#Row1", removed_versions["@id"]);
         }
 

--- a/VersionedObject.sln
+++ b/VersionedObject.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestVersionedObject", "Test
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3E5A0A9D-B063-465A-B19F-4EE7490BC7B5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PerformanceTests", "CLI\PerformanceTests.csproj", "{AAD65EB7-4C19-4766-8829-C2ADF3265C84}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -23,6 +25,10 @@ Global
 		{3CF5E328-F50F-4D8A-97C7-1C8C185018BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3CF5E328-F50F-4D8A-97C7-1C8C185018BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3CF5E328-F50F-4D8A-97C7-1C8C185018BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AAD65EB7-4C19-4766-8829-C2ADF3265C84}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AAD65EB7-4C19-4766-8829-C2ADF3265C84}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AAD65EB7-4C19-4766-8829-C2ADF3265C84}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AAD65EB7-4C19-4766-8829-C2ADF3265C84}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/VersionedObject/EntityGraphComparer.cs
+++ b/VersionedObject/EntityGraphComparer.cs
@@ -42,14 +42,14 @@ namespace VersionedObject
 
         private static JObject HandleGraphUpdate(this JObject input, JObject existing, Func<IEnumerable<PersistentObjectData>, IEnumerable<VersionedObject>, IEnumerable<VersionedIRIReference>> MakeDeleteList)
         {
-            var inputList = input.GetInputGraphAsEntities();
-            var persistentEntities = GetAllPersistentIris(input, existing);
-            var reifiedInput = inputList.ReifyAllEdges(persistentEntities);
-            var existingList = existing.GetExistingGraphAsEntities(persistentEntities);
-            var updateList = reifiedInput.MakeUpdateList(existingList);
+            var inputList = input.GetInputGraphAsEntities().ToImmutableList();
+            var persistentEntities = GetAllPersistentIris(input, existing).ToImmutableList();
+            var reifiedInput = inputList.ReifyAllEdges(persistentEntities).ToImmutableList();
+            var existingList = existing.GetExistingGraphAsEntities(persistentEntities).ToImmutableList();
+            var updateList = reifiedInput.MakeUpdateList(existingList).ToImmutableList();
             var versionedIriMap = existingList.MakeUpdatedPersistentIriMap(updateList);
-            var versionedUpdateList = updateList.UpdateEdgeIris(versionedIriMap);
-            var deleteList = MakeDeleteList(reifiedInput, existingList);
+            var versionedUpdateList = updateList.UpdateEdgeIris(versionedIriMap).ToImmutableList();
+            var deleteList = MakeDeleteList(reifiedInput, existingList).ToImmutableList();
             return CreateUpdateJObject(versionedUpdateList, deleteList);
         }
         /// <summary>

--- a/VersionedObject/EntityGraphComparer.cs
+++ b/VersionedObject/EntityGraphComparer.cs
@@ -43,7 +43,7 @@ namespace VersionedObject
         private static JObject HandleGraphUpdate(this JObject input, JObject existing, Func<IEnumerable<PersistentObjectData>, IEnumerable<VersionedObject>, IEnumerable<VersionedIRIReference>> MakeDeleteList)
         {
             var inputList = input.GetInputGraphAsEntities().ToImmutableList();
-            var persistentEntities = GetAllPersistentIris(input, existing).ToImmutableList();
+            var persistentEntities = GetAllPersistentIris(input, existing).ToImmutableHashSet();
             var reifiedInput = inputList.ReifyAllEdges(persistentEntities).ToImmutableList();
             var existingList = existing.GetExistingGraphAsEntities(persistentEntities).ToImmutableList();
             var updateList = reifiedInput.MakeUpdateList(existingList).ToImmutableList();
@@ -67,7 +67,7 @@ namespace VersionedObject
         /// </summary>
         /// <param name="jsonld"></param>
         /// <param name="persistentUris"></param>
-        public static IEnumerable<VersionedObject> GetExistingGraphAsEntities(this JObject jsonld, IEnumerable<IRIReference> persistentUris) =>
+        public static IEnumerable<VersionedObject> GetExistingGraphAsEntities(this JObject jsonld, ImmutableHashSet<IRIReference> persistentUris) =>
             jsonld.RemoveContext()
                 .GetJsonLdGraph()
                 .Values<JObject>()

--- a/VersionedObject/EntityGraphComparer.cs
+++ b/VersionedObject/EntityGraphComparer.cs
@@ -15,6 +15,7 @@ using System.Linq;
 using System.Runtime.InteropServices.ComTypes;
 using AngleSharp.Common;
 using VDS.RDF.JsonLd;
+using static VersionedObject.JsonLdHelper;
 
 namespace VersionedObject
 {
@@ -188,24 +189,8 @@ namespace VersionedObject
                 select new KeyValuePair<IRIReference, VersionedIRIReference>(obj.GetPersistentIRI(), obj.VersionedIri)
                 );
 
-        /// <summary>
-        /// Adds versions to all references to persistent IRIs in the map argument
-        /// </summary>
-        /// <param name="orig"></param>
-        /// <param name="map"></param>
-        /// <returns></returns>
-        public static PersistentObjectData CreateVersionedIRIs(this PersistentObjectData orig,
-            ImmutableDictionary<IRIReference, VersionedIRIReference> map) =>
-            new(orig.PersistentIRI,
-                JObject.Parse(
-                    map.Keys
-                        .Aggregate(orig.ToJsonldJObject().ToString(),
-                            (json, uri) => json.Replace(uri.ToString(), map[uri].ToString())
-                            )
-                    )
-                );
         public static VersionedObject CreateVersionedIRIs(this VersionedObject orig, ImmutableDictionary<IRIReference, VersionedIRIReference> map) =>
-            new(orig.Object.CreateVersionedIRIs(map), orig.WasDerivedFrom);
+            new(new PersistentObjectData(orig.Object, map), orig.WasDerivedFrom);
 
         public static IEnumerable<VersionedObject> UpdateEdgeIris(this IEnumerable<VersionedObject> updateList,
             ImmutableDictionary<IRIReference, VersionedIRIReference> map) =>

--- a/VersionedObject/JsonLdHelper.cs
+++ b/VersionedObject/JsonLdHelper.cs
@@ -7,8 +7,11 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 
 You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
+
+using System.Collections.Immutable;
 using Newtonsoft.Json.Linq;
 using System.Data.HashFunction.CRC;
+using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
 using VDS.RDF;
@@ -50,7 +53,17 @@ namespace VersionedObject
         /// Removes the version suffix from all persistent URIs in the JObject
         /// </summary>
         public static JObject RemoveVersionFromUris(this JObject versionedEntity,
-            IEnumerable<IRIReference> persistentUris) =>
+            ImmutableHashSet<IRIReference> persistentUris) =>
+            versionedEntity
+                .Properties()
+                .Select(o => 
+                    o.Value switch
+                    {
+                        JValue iri => CreateIriReference
+                    }
+
+                )
+
             JObject.Parse(persistentUris
                 .Aggregate(versionedEntity.ToString(),
                     (ent, persistent) =>

--- a/VersionedObject/PersistentObjectData.cs
+++ b/VersionedObject/PersistentObjectData.cs
@@ -34,14 +34,14 @@ namespace VersionedObject
         }
 
         public PersistentObjectData(JToken persistentIRI, JObject content) : this(new IRIReference(persistentIRI.ToString()), content)
-        {}
+        { }
 
         /// <summary>
         /// Adds versions to all references to persistent IRIs in the map argument
         /// </summary>
         public PersistentObjectData(PersistentObjectData orig,
             ImmutableDictionary<IRIReference, VersionedIRIReference> map) : this(orig.PersistentIRI, new JObject(orig.Content).AddVersionsToUris(map))
-        {}
+        { }
 
         public bool SamePersistentIRI(PersistentObjectData other) =>
             PersistentIRI.ToString().Equals(other.PersistentIRI.ToString());

--- a/VersionedObject/PersistentObjectData.cs
+++ b/VersionedObject/PersistentObjectData.cs
@@ -7,6 +7,7 @@ You should have received a copy of the GNU General Public License along with thi
 using System;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -33,9 +34,14 @@ namespace VersionedObject
         }
 
         public PersistentObjectData(JToken persistentIRI, JObject content) : this(new IRIReference(persistentIRI.ToString()), content)
-        {
-            ;
-        }
+        {}
+
+        /// <summary>
+        /// Adds versions to all references to persistent IRIs in the map argument
+        /// </summary>
+        public PersistentObjectData(PersistentObjectData orig,
+            ImmutableDictionary<IRIReference, VersionedIRIReference> map) : this(orig.PersistentIRI, new JObject(orig.Content).AddVersionsToUris(map))
+        {}
 
         public bool SamePersistentIRI(PersistentObjectData other) =>
             PersistentIRI.ToString().Equals(other.PersistentIRI.ToString());

--- a/VersionedObject/VersionedObject.cs
+++ b/VersionedObject/VersionedObject.cs
@@ -36,14 +36,14 @@ public class VersionedObject
 
     public VersionedObject(VersionedIRIReference versionedIri, JObject content, ImmutableHashSet<IRIReference> persistentIris, VersionedIRIReference wasDerivedFrom)
     {
-        Object = new PersistentObjectData(versionedIri.PersistentIRI, JsonLdHelper.RemoveVersionFromObject(persistentIris)(content));
+        Object = new PersistentObjectData(versionedIri.PersistentIRI, content.RemoveVersionsFromIris(persistentIris));
         VersionedIri = versionedIri;
         WasDerivedFrom = wasDerivedFrom;
     }
 
     public VersionedObject(VersionedIRIReference versionedIri, JObject content, ImmutableHashSet<IRIReference> persistentIris)
     {
-        Object = new PersistentObjectData(versionedIri.PersistentIRI, JsonLdHelper.RemoveVersionFromObject(persistentIris)(content));
+        Object = new PersistentObjectData(versionedIri.PersistentIRI, content.RemoveVersionsFromIris(persistentIris));
         VersionedIri = versionedIri;
         var props = content.Properties();
         var first = content.SelectToken("http://www.w3.org/ns/prov#wasDerivedFrom");

--- a/VersionedObject/VersionedObject.cs
+++ b/VersionedObject/VersionedObject.cs
@@ -5,6 +5,7 @@ This program is distributed in the hope that it will be useful, but WITHOUT ANY 
 You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+using System.Collections.Immutable;
 using Newtonsoft.Json.Linq;
 
 namespace VersionedObject;
@@ -40,7 +41,7 @@ public class VersionedObject
         WasDerivedFrom = wasDerivedFrom;
     }
 
-    public VersionedObject(VersionedIRIReference versionedIri, JObject content, IEnumerable<IRIReference> persistentIris)
+    public VersionedObject(VersionedIRIReference versionedIri, JObject content, ImmutableHashSet<IRIReference> persistentIris)
     {
         Object = new PersistentObjectData(versionedIri.PersistentIRI, content.RemoveVersionFromUris(persistentIris));
         VersionedIri = versionedIri;

--- a/VersionedObject/VersionedObject.cs
+++ b/VersionedObject/VersionedObject.cs
@@ -34,16 +34,16 @@ public class VersionedObject
         WasDerivedFrom = provenance;
     }
 
-    public VersionedObject(VersionedIRIReference versionedIri, JObject content, IEnumerable<IRIReference> persistentIris, VersionedIRIReference wasDerivedFrom)
+    public VersionedObject(VersionedIRIReference versionedIri, JObject content, ImmutableHashSet<IRIReference> persistentIris, VersionedIRIReference wasDerivedFrom)
     {
-        Object = new PersistentObjectData(versionedIri.PersistentIRI, content.RemoveVersionFromUris(persistentIris));
+        Object = new PersistentObjectData(versionedIri.PersistentIRI, JsonLdHelper.RemoveVersionFromObject(persistentIris)(content));
         VersionedIri = versionedIri;
         WasDerivedFrom = wasDerivedFrom;
     }
 
     public VersionedObject(VersionedIRIReference versionedIri, JObject content, ImmutableHashSet<IRIReference> persistentIris)
     {
-        Object = new PersistentObjectData(versionedIri.PersistentIRI, content.RemoveVersionFromUris(persistentIris));
+        Object = new PersistentObjectData(versionedIri.PersistentIRI, JsonLdHelper.RemoveVersionFromObject(persistentIris)(content));
         VersionedIri = versionedIri;
         var props = content.Properties();
         var first = content.SelectToken("http://www.w3.org/ns/prov#wasDerivedFrom");
@@ -56,7 +56,7 @@ public class VersionedObject
 
     }
 
-    public VersionedObject(JToken versionedIri, JObject content, IEnumerable<IRIReference> persistentIris, VersionedIRIReference wasDerivedFrom) : this(new VersionedIRIReference(versionedIri.ToString()), content, persistentIris, wasDerivedFrom)
+    public VersionedObject(JToken versionedIri, JObject content, ImmutableHashSet<IRIReference> persistentIris, VersionedIRIReference wasDerivedFrom) : this(new VersionedIRIReference(versionedIri.ToString()), content, persistentIris, wasDerivedFrom)
     { }
 
 


### PR DESCRIPTION
Fixes issue #34 

A new project "PerformanceTest" includes flat auto-generated data with variable number of entries. This program now runs on 10 000 entries in 1.25 minutes

Use of ImmutableList several places to avoid double enumeration. 

Replaced the implementation of JsonLdHelper.RemoveVersionsFromIris with a more efficient version that avoids quadratic runtime.