### PR TITLE
Testing blank nodes

### DIFF
--- a/TestVersionedObject/VersionedObjectTests.cs
+++ b/TestVersionedObject/VersionedObjectTests.cs
@@ -420,6 +420,33 @@ namespace VersionedObject.Tests
         }
 
         [Fact]
+        public void TestIsBlankNode()
+        {
+            var bnode = new JObject()
+            {
+                ["@type"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003589",
+                ["@id"] = "_:1234",
+                ["rdfs:label"] = "Weight of object"
+            };
+        Assert.True(bnode.IsBlankNode());
+
+        var bnode2 = new JObject()
+        {
+            ["@type"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003589",
+            ["rdfs:label"] = "Weight of object"
+        };
+        Assert.True(bnode.IsBlankNode());
+
+        var normal_node = new JObject()
+        {
+            ["@type"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003589",
+            ["@id"] = "http://example.com/id/_1",
+            ["rdfs:label"] = "Weight of object"
+        };
+        Assert.False(normal_node.IsBlankNode());
+        }
+
+        [Fact]
         public void BlankNodeTest()
         {
             var obj1 = BlankNodeJsonLd.GetInputGraphAsEntities().First();
@@ -504,20 +531,20 @@ namespace VersionedObject.Tests
         [Fact()]
         public void TestHashTriples()
         {
-            var simple_graph = ParseJsonLdString(SimpleJsonLd.ToString());
-            var aspect_persistent_graph = ParseJsonLdString(aspect_persistent_jsonld.ToString());
-            var simple_aspect_graph = ParseJsonLdString(SimpleJsonLd.ToString());
-            var aspect_graph = ParseJsonLdString(aspect_jsonld.ToString());
+            var simple_graph = SimpleJsonLd;
+            var aspect_persistent_graph = aspect_persistent_jsonld;
+            var simple_aspect_graph = SimpleJsonLd;
+            var aspect_graph = aspect_jsonld;
             var simple_expanded = SimpleJsonLd.RemoveContext();
             var aspet_persistent_expanded = aspect_persistent_jsonld.RemoveContext();
             Assert.True(simple_expanded.AspectEquals(aspet_persistent_expanded, RdfEqualsHash));
 
             var simple_hash = simple_graph.GetHash();
             var simple_aspect_hash = simple_aspect_graph.GetHash();
-            var different_hash = ParseJsonLdString(DifferentJsonLd.ToString()).GetHash();
+            var different_hash = DifferentJsonLd.GetHash();
             var aspect_hash = aspect_graph.GetHash();
             var aspect_persistent_hash = aspect_persistent_graph.GetHash();
-            var row2_hash = ParseJsonLdString(Row2JsonLd.ToString()).GetHash();
+            var row2_hash = Row2JsonLd.GetHash();
             Assert.NotEqual(simple_hash, different_hash);
             Assert.NotEqual(aspect_hash, different_hash);
             Assert.NotEqual(row2_hash, different_hash);

--- a/TestVersionedObject/VersionedObjectTests.cs
+++ b/TestVersionedObject/VersionedObjectTests.cs
@@ -182,7 +182,7 @@ namespace VersionedObject.Tests
                             ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "22",
                             ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
                         },
-                            
+
                             new JObject()
                             {
                                 ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
@@ -428,22 +428,22 @@ namespace VersionedObject.Tests
                 ["@id"] = "_:1234",
                 ["rdfs:label"] = "Weight of object"
             };
-        Assert.True(bnode.IsBlankNode());
+            Assert.True(bnode.IsBlankNode());
 
-        var bnode2 = new JObject()
-        {
-            ["@type"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003589",
-            ["rdfs:label"] = "Weight of object"
-        };
-        Assert.True(bnode.IsBlankNode());
+            var bnode2 = new JObject()
+            {
+                ["@type"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003589",
+                ["rdfs:label"] = "Weight of object"
+            };
+            Assert.True(bnode.IsBlankNode());
 
-        var normal_node = new JObject()
-        {
-            ["@type"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003589",
-            ["@id"] = "http://example.com/id/_1",
-            ["rdfs:label"] = "Weight of object"
-        };
-        Assert.False(normal_node.IsBlankNode());
+            var normal_node = new JObject()
+            {
+                ["@type"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003589",
+                ["@id"] = "http://example.com/id/_1",
+                ["rdfs:label"] = "Weight of object"
+            };
+            Assert.False(normal_node.IsBlankNode());
         }
 
         [Fact]
@@ -508,7 +508,7 @@ namespace VersionedObject.Tests
         [Fact()]
         public void LoadStringGraphTest()
         {
-            var graph = ParseJsonLdGraph(JObject.Parse( @"{
+            var graph = ParseJsonLdGraph(JObject.Parse(@"{
                 ""@graph"": [
                     {
                         ""@id"": ""sor:Row1"",

--- a/TestVersionedObject/VersionedObjectTests.cs
+++ b/TestVersionedObject/VersionedObjectTests.cs
@@ -13,7 +13,7 @@ namespace VersionedObject.Tests
 {
     public class VersionedObjectTests
     {
-        
+
         public static JObject row1_maker(string? id = "sor:Row1", string? type = "MelRow", string? label = "An empty MEL Row") =>
             new JObject()
             {
@@ -25,7 +25,7 @@ namespace VersionedObject.Tests
         public static readonly JObject row1 = row1_maker();
         public static readonly JObject different_row1 = row1_maker(label: "A different MEL Row");
         public static readonly JObject row2 = row1_maker(id: "sor:Row2", label: "The second MEL Row");
-    
+
         public static readonly JObject context = new()
         {
             ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",
@@ -67,7 +67,7 @@ namespace VersionedObject.Tests
             new(GetWeightDatumObject(weight).Properties().Append(new JProperty("@id", id)));
 
         public static JObject GetWeightQualityObject(JArray weights) =>
-            new ()
+            new()
             {
                 ["@type"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003589",
                 ["rdfs:label"] = "Weight of object",
@@ -89,37 +89,37 @@ namespace VersionedObject.Tests
 
         public static readonly JObject BlankNodeJsonLd = new()
         {
-            ["@graph"] = new JArray() { GetRow1WithWeights(GetWeightQualityObject(new JArray() {GetWeightDatumObject(12345), GetWeightDatumObject(23456)})) },
+            ["@graph"] = new JArray() { GetRow1WithWeights(GetWeightQualityObject(new JArray() { GetWeightDatumObject(12345), GetWeightDatumObject(23456) })) },
             ["@context"] = context
         };
 
         public static readonly JObject BlankNodeJsonLd2 = new()
         {
-            ["@graph"] = new JArray() { GetRow1WithWeights(GetWeightQualityObject(new JArray(){GetWeightDatumObject(12345, "_:212"), GetWeightDatumObject(23456)}, "_:1234")) },
+            ["@graph"] = new JArray() { GetRow1WithWeights(GetWeightQualityObject(new JArray() { GetWeightDatumObject(12345, "_:212"), GetWeightDatumObject(23456) }, "_:1234")) },
             ["@context"] = context
         };
 
         public static readonly JObject BlankNodeJsonLd2a = new()
         {
-            ["@graph"] = new JArray(){ GetRow1WithWeights(GetWeightQualityObject(new JArray(){GetWeightDatumObject(1), GetWeightDatumObject(22), GetWeightDatumObject(333)}, "_:1234"))},
+            ["@graph"] = new JArray() { GetRow1WithWeights(GetWeightQualityObject(new JArray() { GetWeightDatumObject(1), GetWeightDatumObject(22), GetWeightDatumObject(333) }, "_:1234")) },
             ["@context"] = context
         };
 
         public static readonly JObject BlankNodeJsonLd2b = new()
         {
-            ["@graph"] = new JArray(){ GetRow1WithWeights(GetWeightQualityObject(new JArray(){ GetWeightDatumObject(333), GetWeightDatumObject(1), GetWeightDatumObject(22)}, "_:1234"))},
+            ["@graph"] = new JArray() { GetRow1WithWeights(GetWeightQualityObject(new JArray() { GetWeightDatumObject(333), GetWeightDatumObject(1), GetWeightDatumObject(22) }, "_:1234")) },
             ["@context"] = context
         };
 
         public static readonly JObject BlankNodeJsonLd3 = new()
         {
-            ["@graph"] = new JArray() { GetRow1WithWeights(GetWeightQualityObject(new JArray(){ GetWeightDatumObject(12346) }, "_:1")) },
+            ["@graph"] = new JArray() { GetRow1WithWeights(GetWeightQualityObject(new JArray() { GetWeightDatumObject(12346) }, "_:1")) },
             ["@context"] = context
         };
 
         public static readonly JObject BlankNodeJsonLd4 = new()
         {
-            ["@graph"] = new JArray(){ GetRow1WithWeights(GetWeightQualityObject(new JArray(GetWeightDatumObject(12346, "_:evenweirderlongblankid")){}, "_:strangelongblankid"))},
+            ["@graph"] = new JArray() { GetRow1WithWeights(GetWeightQualityObject(new JArray(GetWeightDatumObject(12346, "_:evenweirderlongblankid")) { }, "_:strangelongblankid")) },
             ["@context"] = context
         };
 

--- a/TestVersionedObject/VersionedObjectTests.cs
+++ b/TestVersionedObject/VersionedObjectTests.cs
@@ -73,6 +73,197 @@ namespace VersionedObject.Tests
             }
         };
 
+        public static readonly JObject BlankNodeJsonLd = new()
+        {
+            ["@graph"] = new JArray()
+            {
+                new JObject()
+                {
+                    ["@id"] = "sor:Row1",
+                    ["@type"] = "MelRow",
+                    ["rdfs:label"] = "An empty MEL Row",
+                    ["http://rds.posccaesar.org/ontology/lis14/rdl/hasPhysicalQuantity"] = new JObject()
+                    {
+                        ["@type"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003589",
+                        ["rdfs:label"] = "Weight of object",
+                        ["http://rds.posccaesar.org/ontology/lis14/rdl/qualityQuantifiedAs"] = new JArray(){
+                            new JObject()
+                        {
+                            ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
+                            ["rdfs:label"] = "Weight specified",
+                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "12345",
+                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
+                        },
+                            new JObject(){
+                                ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
+                                ["rdfs:label"] = "Weight specified",
+                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "23456",
+                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
+                                }
+                            }
+                    }
+                }
+            },
+            ["@context"] = new JObject()
+            {
+                ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",
+                ["@vocab"] = "http://rdf.equinor.com/ontology/mel#",
+                ["sor"] = "http://rdf.equinor.com/ontology/sor#",
+                ["@version"] = "1.1"
+            }
+        };
+
+        public static readonly JObject BlankNodeJsonLd2 = new()
+        {
+            ["@graph"] = new JArray()
+            {
+                new JObject()
+                {
+                    ["@id"] = "sor:Row1",
+                    ["@type"] = "MelRow",
+                    ["rdfs:label"] = "An empty MEL Row",
+                    ["http://rds.posccaesar.org/ontology/lis14/rdl/hasPhysicalQuantity"] = new JObject()
+                    {
+                        ["@type"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003589",
+                        ["@id"] = "_:1234",
+                        ["rdfs:label"] = "Weight of object",
+                        ["http://rds.posccaesar.org/ontology/lis14/rdl/qualityQuantifiedAs"] = new JArray(){ new JObject()
+                        {
+                            ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
+                            ["@id"] = "_:212",
+                            ["rdfs:label"] = "Weight specified",
+                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "12345",
+                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
+                        },
+                            new JObject(){
+                                ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
+                                ["rdfs:label"] = "Weight specified",
+                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "23456",
+                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
+                            }
+                        }
+                    }
+                }
+            },
+            ["@context"] = new JObject()
+            {
+                ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",
+                ["@vocab"] = "http://rdf.equinor.com/ontology/mel#",
+                ["sor"] = "http://rdf.equinor.com/ontology/sor#",
+                ["@version"] = "1.1"
+            }
+        };
+
+        public static readonly JObject BlankNodeJsonLd2a = new()
+        {
+            ["@graph"] = new JArray()
+            {
+                new JObject()
+                {
+                    ["@id"] = "sor:Row1",
+                    ["@type"] = "MelRow",
+                    ["rdfs:label"] = "An empty MEL Row",
+                    ["http://rds.posccaesar.org/ontology/lis14/rdl/hasPhysicalQuantity"] = new JObject()
+                    {
+                        ["@type"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003589",
+                        ["@id"] = "_:1234",
+                        ["rdfs:label"] = "Weight of object",
+                        ["http://rds.posccaesar.org/ontology/lis14/rdl/qualityQuantifiedAs"] = new JArray(){
+                            new JObject(){
+                                ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
+                                ["rdfs:label"] = "Weight specified",
+                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "23456",
+                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
+                            },
+                            new JObject()
+                        {
+                            ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
+                            ["@id"] = "_:strangeweightid",
+                            ["rdfs:label"] = "Weight specified",
+                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "12345",
+                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
+                        }
+                        }
+                    }
+                }
+            },
+            ["@context"] = new JObject()
+            {
+                ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",
+                ["@vocab"] = "http://rdf.equinor.com/ontology/mel#",
+                ["sor"] = "http://rdf.equinor.com/ontology/sor#",
+                ["@version"] = "1.1"
+            }
+        };
+
+        public static readonly JObject BlankNodeJsonLd3 = new()
+        {
+            ["@graph"] = new JArray()
+            {
+                new JObject()
+                {
+                    ["@id"] = "sor:Row1",
+                    ["@type"] = "MelRow",
+                    ["rdfs:label"] = "An empty MEL Row",
+                    ["http://rds.posccaesar.org/ontology/lis14/rdl/hasPhysicalQuantity"] = new JObject()
+                    {
+                        ["@type"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003589",
+                        ["@id"] = "_:1",
+                        ["rdfs:label"] = "Weight of object",
+                        ["http://rds.posccaesar.org/ontology/lis14/rdl/qualityQuantifiedAs"] = new JObject()
+                        {
+                            ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
+                            ["@id"] = "_:2",
+                            ["rdfs:label"] = "Weight specified",
+                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "12346",
+                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
+                        }
+                    }
+                }
+            },
+            ["@context"] = new JObject()
+            {
+                ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",
+                ["@vocab"] = "http://rdf.equinor.com/ontology/mel#",
+                ["sor"] = "http://rdf.equinor.com/ontology/sor#",
+                ["@version"] = "1.1"
+            }
+        };
+
+        public static readonly JObject BlankNodeJsonLd4 = new()
+        {
+            ["@graph"] = new JArray()
+            {
+                new JObject()
+                {
+                    ["@id"] = "sor:Row1",
+                    ["@type"] = "MelRow",
+                    ["rdfs:label"] = "An empty MEL Row",
+                    ["http://rds.posccaesar.org/ontology/lis14/rdl/hasPhysicalQuantity"] = new JObject()
+                    {
+                        ["@type"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003589",
+                        ["@id"] = "_:strangelongblankid",
+                        ["rdfs:label"] = "Weight of object",
+                        ["http://rds.posccaesar.org/ontology/lis14/rdl/qualityQuantifiedAs"] = new JObject()
+                        {
+                            ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
+                            ["@id"] = "_:evenweirderlongblankid",
+                            ["rdfs:label"] = "Weight specified",
+                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "12346",
+                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
+                        }
+                    }
+                }
+            },
+            ["@context"] = new JObject()
+            {
+                ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",
+                ["@vocab"] = "http://rdf.equinor.com/ontology/mel#",
+                ["sor"] = "http://rdf.equinor.com/ontology/sor#",
+                ["@version"] = "1.1"
+            }
+        };
+
         public static readonly JObject aspect_jsonld = new()
         {
             ["@graph"] = new JArray()
@@ -172,6 +363,26 @@ namespace VersionedObject.Tests
             Assert.Equal(aspectHashCode, aspectFirst.VersionedIri.VersionHash);
         }
 
+        [Fact]
+        public void BlankNodeTest()
+        {
+            var obj1 = BlankNodeJsonLd.GetInputGraphAsEntities().First();
+            var hash1 = obj1.GetHash();
+            var obj2 = BlankNodeJsonLd2.GetInputGraphAsEntities().First();
+            var hash2 = obj2.GetHash();
+            var obj2a = BlankNodeJsonLd2a.GetInputGraphAsEntities().First();
+            var hash2a = obj2.GetHash();
+            var obj3 = BlankNodeJsonLd3.GetInputGraphAsEntities().First();
+            var hash3 = obj3.GetHash();
+            var obj4 = BlankNodeJsonLd4.GetInputGraphAsEntities().First();
+            var hash4 = obj4.GetHash();
+
+            Assert.Equal(obj2.GetHash(), obj1.GetHash());
+            Assert.Equal(obj2.GetHash(), obj2a.GetHash());
+            Assert.Equal(obj3.GetHash(), obj4.GetHash());
+            Assert.NotEqual(obj1.GetHash(), obj3.GetHash());
+            Assert.NotEqual(obj2.GetHash(), obj4.GetHash());
+        }
 
         [Fact()]
         public void LoadGraphTest()

--- a/TestVersionedObject/VersionedObjectTests.cs
+++ b/TestVersionedObject/VersionedObjectTests.cs
@@ -157,7 +157,7 @@ namespace VersionedObject.Tests
                 }
             },
             ["@context"] = context
-                };
+        };
 
         public static JObject GetWeightDatumObject(int weight, string id) =>
             new(GetWeightDatumObject(weight).Properties().Append(new JProperty("@id", id)));

--- a/TestVersionedObject/VersionedObjectTests.cs
+++ b/TestVersionedObject/VersionedObjectTests.cs
@@ -172,17 +172,73 @@ namespace VersionedObject.Tests
                             new JObject(){
                                 ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
                                 ["rdfs:label"] = "Weight specified",
-                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "23456",
+                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "1",
                                 ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
                             },
                             new JObject()
                         {
                             ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
-                            ["@id"] = "_:strangeweightid",
                             ["rdfs:label"] = "Weight specified",
-                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "12345",
+                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "22",
                             ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
+                        },
+                            
+                            new JObject()
+                            {
+                                ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
+                                ["rdfs:label"] = "Weight specified",
+                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "333",
+                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
+                            }
                         }
+                    }
+                }
+            },
+            ["@context"] = new JObject()
+            {
+                ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",
+                ["@vocab"] = "http://rdf.equinor.com/ontology/mel#",
+                ["sor"] = "http://rdf.equinor.com/ontology/sor#",
+                ["@version"] = "1.1"
+            }
+        };
+
+        public static readonly JObject BlankNodeJsonLd2b = new()
+        {
+            ["@graph"] = new JArray()
+            {
+                new JObject()
+                {
+                    ["@id"] = "sor:Row1",
+                    ["@type"] = "MelRow",
+                    ["rdfs:label"] = "An empty MEL Row",
+                    ["http://rds.posccaesar.org/ontology/lis14/rdl/hasPhysicalQuantity"] = new JObject()
+                    {
+                        ["@type"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003589",
+                        ["@id"] = "_:1234",
+                        ["rdfs:label"] = "Weight of object",
+                        ["http://rds.posccaesar.org/ontology/lis14/rdl/qualityQuantifiedAs"] = new JArray(){
+                            new JObject(){
+                                ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
+                                ["rdfs:label"] = "Weight specified",
+                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "333",
+                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
+                            },
+                            new JObject()
+                        {
+                            ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
+                            ["rdfs:label"] = "Weight specified",
+                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "1",
+                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
+                        },
+
+                            new JObject()
+                            {
+                                ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
+                                ["rdfs:label"] = "Weight specified",
+                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "22",
+                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
+                            }
                         }
                     }
                 }
@@ -371,14 +427,17 @@ namespace VersionedObject.Tests
             var obj2 = BlankNodeJsonLd2.GetInputGraphAsEntities().First();
             var hash2 = obj2.GetHash();
             var obj2a = BlankNodeJsonLd2a.GetInputGraphAsEntities().First();
-            var hash2a = obj2.GetHash();
+            var hash2a = obj2a.GetHash();
+            var obj2b = BlankNodeJsonLd2b.GetInputGraphAsEntities().First();
+            var hash2b = obj2b.GetHash();
             var obj3 = BlankNodeJsonLd3.GetInputGraphAsEntities().First();
             var hash3 = obj3.GetHash();
             var obj4 = BlankNodeJsonLd4.GetInputGraphAsEntities().First();
             var hash4 = obj4.GetHash();
 
             Assert.Equal(obj2.GetHash(), obj1.GetHash());
-            Assert.Equal(obj2.GetHash(), obj2a.GetHash());
+            Assert.NotEqual(obj2.GetHash(), obj2a.GetHash());
+            Assert.Equal(obj2b.GetHash(), obj2a.GetHash());
             Assert.Equal(obj3.GetHash(), obj4.GetHash());
             Assert.NotEqual(obj1.GetHash(), obj3.GetHash());
             Assert.NotEqual(obj2.GetHash(), obj4.GetHash());

--- a/TestVersionedObject/VersionedObjectTests.cs
+++ b/TestVersionedObject/VersionedObjectTests.cs
@@ -464,7 +464,7 @@ namespace VersionedObject.Tests
 
             Assert.Equal(obj2.GetHash(), obj1.GetHash());
             Assert.NotEqual(obj2.GetHash(), obj2a.GetHash());
-            Assert.Equal(obj2b.GetHash(), obj2a.GetHash());
+             Assert.Equal(obj2b.GetHash(), obj2a.GetHash());
             Assert.Equal(obj3.GetHash(), obj4.GetHash());
             Assert.NotEqual(obj1.GetHash(), obj3.GetHash());
             Assert.NotEqual(obj2.GetHash(), obj4.GetHash());

--- a/TestVersionedObject/VersionedObjectTests.cs
+++ b/TestVersionedObject/VersionedObjectTests.cs
@@ -558,20 +558,20 @@ namespace VersionedObject.Tests
         [Fact()]
         public void TestHashTriples()
         {
-            var simple_graph = SimpleJsonLd;
-            var aspect_persistent_graph = aspect_persistent_jsonld;
-            var simple_aspect_graph = SimpleJsonLd;
-            var aspect_graph = aspect_jsonld;
+            var simple_graph = SimpleJsonLd.GetInputGraphAsEntities().First();
+            var aspect_persistent_graph = aspect_persistent_jsonld.GetInputGraphAsEntities().First();
+            var simple_aspect_graph = SimpleJsonLd.GetInputGraphAsEntities().First();
+            var aspect_graph = aspect_jsonld.GetInputGraphAsEntities().First();
             var simple_expanded = SimpleJsonLd.RemoveContext();
             var aspet_persistent_expanded = aspect_persistent_jsonld.RemoveContext();
             Assert.True(simple_expanded.AspectEquals(aspet_persistent_expanded, RdfEqualsHash));
 
             var simple_hash = simple_graph.GetHash();
             var simple_aspect_hash = simple_aspect_graph.GetHash();
-            var different_hash = DifferentJsonLd.GetHash();
+            var different_hash = DifferentJsonLd.GetInputGraphAsEntities().First().GetHash();
             var aspect_hash = aspect_graph.GetHash();
             var aspect_persistent_hash = aspect_persistent_graph.GetHash();
-            var row2_hash = Row2JsonLd.GetHash();
+            var row2_hash = Row2JsonLd.GetInputGraphAsEntities().First().GetHash();
             Assert.NotEqual(simple_hash, different_hash);
             Assert.NotEqual(aspect_hash, different_hash);
             Assert.NotEqual(row2_hash, different_hash);

--- a/TestVersionedObject/VersionedObjectTests.cs
+++ b/TestVersionedObject/VersionedObjectTests.cs
@@ -13,249 +13,127 @@ namespace VersionedObject.Tests
 {
     public class VersionedObjectTests
     {
+
+
+        public VersionedObjectTests()
+        {
+            var object1 = new
+            {
+                id = "sow:Row1",
+                type = "MelRow",
+                label = "A different MEL Row"
+            };
+        }
+
+        public static readonly JObject row1 = new JObject()
+        {
+            ["@id"] = "sor:Row1",
+            ["@type"] = "MelRow",
+            ["rdfs:label"] = "An empty MEL Row"
+        };
+
+        public static readonly JObject different_row1 = new()
+        {
+            ["@id"] = "sor:Row1",
+            ["@type"] = "MelRow",
+            ["rdfs:label"] = "A different MEL Row"
+        };
+
+        public static readonly JObject row2 = new()
+        {
+            ["@id"] = "sor:Row2",
+            ["@type"] = "MelRow",
+            ["rdfs:label"] = "The second MEL Row"
+        };
+
+        public static readonly JObject context = new()
+        {
+            ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",
+            ["@vocab"] = "http://rdf.equinor.com/ontology/mel#",
+            ["sor"] = "http://rdf.equinor.com/ontology/sor#",
+            ["@version"] = "1.1"
+        };
+
         public static readonly JObject DifferentJsonLd = new()
         {
-            ["@graph"] = new JArray()
-                {
-                    new JObject()
-                    {
-                        ["@id"] = "sor:Row1",
-                        ["@type"] = "MelRow",
-                        ["rdfs:label"] = "A different MEL Row"
-                    }
-                },
-            ["@context"] = new JObject()
-            {
-                ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",
-                ["@vocab"] = "http://rdf.equinor.com/ontology/mel#",
-                ["sor"] = "http://rdf.equinor.com/ontology/sor#",
-                ["@version"] = "1.1"
-            }
+            ["@graph"] = new JArray() { different_row1 },
+            ["@context"] = context
         };
 
         public static readonly JObject Row2JsonLd = new()
         {
-            ["@graph"] = new JArray()
-                {
-                    new JObject()
-                    {
-                        ["@id"] = "sor:Row2",
-                        ["@type"] = "MelRow",
-                        ["rdfs:label"] = "The second MEL Row"
-                    }
-                },
-            ["@context"] = new JObject()
-            {
-                ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",
-                ["@vocab"] = "http://rdf.equinor.com/ontology/mel#",
-                ["sor"] = "http://rdf.equinor.com/ontology/sor#",
-                ["@version"] = "1.1"
-            }
+            ["@graph"] = new JArray() { row2 },
+            ["@context"] = context
         };
 
         public static readonly JObject SimpleJsonLd = new()
         {
-            ["@graph"] = new JArray()
-                {
-                    new JObject()
-                    {
-                        ["@id"] = "sor:Row1",
-                        ["@type"] = "MelRow",
-                        ["rdfs:label"] = "An empty MEL Row"
-                    }
-                },
-            ["@context"] = new JObject()
-            {
-                ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",
-                ["@vocab"] = "http://rdf.equinor.com/ontology/mel#",
-                ["sor"] = "http://rdf.equinor.com/ontology/sor#",
-                ["@version"] = "1.1"
-            }
+            ["@graph"] = new JArray() { row1 },
+            ["@context"] = context
         };
+
+        public static JObject GetWeightDatumObject(int weight) =>
+            new()
+            {
+                ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620",
+                    "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
+                ["rdfs:label"] = "Weight specified",
+                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = weight.ToString(),
+                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] =
+                    "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
+            };
+
+        public static JObject GetWeightDatumObject(int weight, string id) =>
+            new(GetWeightDatumObject(weight).Properties().Append(new JProperty("@id", id)));
+
+        public static JObject GetWeightQualityObject(JArray weights) =>
+            new ()
+            {
+                ["@type"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003589",
+                ["rdfs:label"] = "Weight of object",
+                ["http://rds.posccaesar.org/ontology/lis14/rdl/qualityQuantifiedAs"] = weights
+            };
+
+        public static JObject GetWeightQualityObject(JArray weights, string id) =>
+            new(GetWeightQualityObject(weights).Properties().Append(new JProperty("@id", id)));
+
+        public static JObject GetRow1WithWeights(JObject quality) =>
+            new(row1
+                .Properties()
+                .Append(new JProperty(
+                    "http://rds.posccaesar.org/ontology/lis14/rdl/hasPhysicalQuantity",
+                    quality
+                    )
+                )
+            );
 
         public static readonly JObject BlankNodeJsonLd = new()
         {
-            ["@graph"] = new JArray()
-            {
-                new JObject()
-                {
-                    ["@id"] = "sor:Row1",
-                    ["@type"] = "MelRow",
-                    ["rdfs:label"] = "An empty MEL Row",
-                    ["http://rds.posccaesar.org/ontology/lis14/rdl/hasPhysicalQuantity"] = new JObject()
-                    {
-                        ["@type"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003589",
-                        ["rdfs:label"] = "Weight of object",
-                        ["http://rds.posccaesar.org/ontology/lis14/rdl/qualityQuantifiedAs"] = new JArray(){
-                            new JObject()
-                        {
-                            ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
-                            ["rdfs:label"] = "Weight specified",
-                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "12345",
-                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
-                        },
-                            new JObject(){
-                                ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
-                                ["rdfs:label"] = "Weight specified",
-                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "23456",
-                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
-                                }
-                            }
-                    }
-                }
-            },
-            ["@context"] = new JObject()
-            {
-                ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",
-                ["@vocab"] = "http://rdf.equinor.com/ontology/mel#",
-                ["sor"] = "http://rdf.equinor.com/ontology/sor#",
-                ["@version"] = "1.1"
-            }
+            ["@graph"] = new JArray() { GetRow1WithWeights(GetWeightQualityObject(new JArray() {GetWeightDatumObject(12345), GetWeightDatumObject(23456)})) },
+            ["@context"] = context
         };
 
         public static readonly JObject BlankNodeJsonLd2 = new()
         {
-            ["@graph"] = new JArray()
-            {
-                new JObject()
-                {
-                    ["@id"] = "sor:Row1",
-                    ["@type"] = "MelRow",
-                    ["rdfs:label"] = "An empty MEL Row",
-                    ["http://rds.posccaesar.org/ontology/lis14/rdl/hasPhysicalQuantity"] = new JObject()
-                    {
-                        ["@type"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003589",
-                        ["@id"] = "_:1234",
-                        ["rdfs:label"] = "Weight of object",
-                        ["http://rds.posccaesar.org/ontology/lis14/rdl/qualityQuantifiedAs"] = new JArray(){ new JObject()
-                        {
-                            ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
-                            ["@id"] = "_:212",
-                            ["rdfs:label"] = "Weight specified",
-                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "12345",
-                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
-                        },
-                            new JObject(){
-                                ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
-                                ["rdfs:label"] = "Weight specified",
-                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "23456",
-                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
-                            }
-                        }
-                    }
-                }
-            },
-            ["@context"] = new JObject()
-            {
-                ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",
-                ["@vocab"] = "http://rdf.equinor.com/ontology/mel#",
-                ["sor"] = "http://rdf.equinor.com/ontology/sor#",
-                ["@version"] = "1.1"
-            }
+            ["@graph"] = new JArray() { GetRow1WithWeights(GetWeightQualityObject(new JArray(){GetWeightDatumObject(12345, "_:212"), GetWeightDatumObject(23456)}, "_:1234")) },
+            ["@context"] = context
         };
 
         public static readonly JObject BlankNodeJsonLd2a = new()
         {
-            ["@graph"] = new JArray()
-            {
-                new JObject()
-                {
-                    ["@id"] = "sor:Row1",
-                    ["@type"] = "MelRow",
-                    ["rdfs:label"] = "An empty MEL Row",
-                    ["http://rds.posccaesar.org/ontology/lis14/rdl/hasPhysicalQuantity"] = new JObject()
-                    {
-                        ["@type"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003589",
-                        ["@id"] = "_:1234",
-                        ["rdfs:label"] = "Weight of object",
-                        ["http://rds.posccaesar.org/ontology/lis14/rdl/qualityQuantifiedAs"] = new JArray(){
-                            new JObject(){
-                                ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
-                                ["rdfs:label"] = "Weight specified",
-                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "1",
-                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
-                            },
-                            new JObject()
-                        {
-                            ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
-                            ["rdfs:label"] = "Weight specified",
-                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "22",
-                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
-                        },
-
-                            new JObject()
-                            {
-                                ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
-                                ["rdfs:label"] = "Weight specified",
-                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "333",
-                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
-                            }
-                        }
-                    }
-                }
-            },
-            ["@context"] = new JObject()
-            {
-                ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",
-                ["@vocab"] = "http://rdf.equinor.com/ontology/mel#",
-                ["sor"] = "http://rdf.equinor.com/ontology/sor#",
-                ["@version"] = "1.1"
-            }
+            ["@graph"] = new JArray(){ GetRow1WithWeights(GetWeightQualityObject(new JArray(){GetWeightDatumObject(1), GetWeightDatumObject(22), GetWeightDatumObject(333)}, "_:1234"))},
+            ["@context"] = context
         };
 
         public static readonly JObject BlankNodeJsonLd2b = new()
         {
-            ["@graph"] = new JArray()
-            {
-                new JObject()
-                {
-                    ["@id"] = "sor:Row1",
-                    ["@type"] = "MelRow",
-                    ["rdfs:label"] = "An empty MEL Row",
-                    ["http://rds.posccaesar.org/ontology/lis14/rdl/hasPhysicalQuantity"] = new JObject()
-                    {
-                        ["@type"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003589",
-                        ["@id"] = "_:1234",
-                        ["rdfs:label"] = "Weight of object",
-                        ["http://rds.posccaesar.org/ontology/lis14/rdl/qualityQuantifiedAs"] = new JArray(){
-                            new JObject(){
-                                ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
-                                ["rdfs:label"] = "Weight specified",
-                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "333",
-                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
-                            },
-                            new JObject()
-                        {
-                            ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
-                            ["rdfs:label"] = "Weight specified",
-                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "1",
-                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
-                        },
-
-                            new JObject()
-                            {
-                                ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
-                                ["rdfs:label"] = "Weight specified",
-                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "22",
-                                ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
-                            }
-                        }
-                    }
-                }
-            },
-            ["@context"] = new JObject()
-            {
-                ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",
-                ["@vocab"] = "http://rdf.equinor.com/ontology/mel#",
-                ["sor"] = "http://rdf.equinor.com/ontology/sor#",
-                ["@version"] = "1.1"
-            }
+            ["@graph"] = new JArray(){ GetRow1WithWeights(GetWeightQualityObject(new JArray(){ GetWeightDatumObject(333), GetWeightDatumObject(1), GetWeightDatumObject(22)}, "_:1234"))},
+            ["@context"] = context
         };
 
         public static readonly JObject BlankNodeJsonLd3 = new()
         {
-            ["@graph"] = new JArray()
-            {
+            ["@graph"] = new JArray() { 
                 new JObject()
                 {
                     ["@id"] = "sor:Row1",

--- a/TestVersionedObject/VersionedObjectTests.cs
+++ b/TestVersionedObject/VersionedObjectTests.cs
@@ -447,6 +447,33 @@ namespace VersionedObject.Tests
         }
 
         [Fact]
+        public void AddBlankNodeIdTest()
+        {
+            var bnode = new JObject()
+            {
+                ["@type"] = "http://example.com/type"
+            };
+            var new_node = AddBlankNodeId(bnode);
+            Assert.True(bnode.IsBlankNode());
+            Assert.NotEqual(new_node, bnode);
+            Assert.NotNull(new_node["@id"]);
+
+        }
+
+        [Fact]
+        public void HashBlankNodesTest()
+        {
+            var hashed = BlankNodeJsonLd2a["@graph"].First().Value<JObject>().HashBlankNodes();
+            Assert.NotEqual(hashed, BlankNodeJsonLd2a);
+            var bnode = new JObject()
+            {
+                ["@type"] = "http://example.com/type"
+            };
+            var new_node = AddBlankNodeId(bnode);
+            var hashed_bnode = bnode.HashBlankNodes();
+        }
+
+        [Fact]
         public void BlankNodeTest()
         {
             var obj1 = BlankNodeJsonLd.GetInputGraphAsEntities().First();
@@ -463,8 +490,8 @@ namespace VersionedObject.Tests
             var hash4 = obj4.GetHash();
 
             Assert.Equal(obj2.GetHash(), obj1.GetHash());
-            Assert.NotEqual(obj2.GetHash(), obj2a.GetHash());
-             Assert.Equal(obj2b.GetHash(), obj2a.GetHash());
+            Assert.NotEqual(obj2a.GetHash(), obj2.GetHash());
+            Assert.Equal(obj2a.GetHash(), obj2b.GetHash());
             Assert.Equal(obj3.GetHash(), obj4.GetHash());
             Assert.NotEqual(obj1.GetHash(), obj3.GetHash());
             Assert.NotEqual(obj2.GetHash(), obj4.GetHash());
@@ -473,7 +500,7 @@ namespace VersionedObject.Tests
         [Fact()]
         public void LoadGraphTest()
         {
-            var graph = ParseJsonLdString(SimpleJsonLd.ToString());
+            var graph = ParseJsonLdGraph(SimpleJsonLd);
             Assert.NotNull(graph);
             Assert.False(graph.IsEmpty);
         }
@@ -481,7 +508,7 @@ namespace VersionedObject.Tests
         [Fact()]
         public void LoadStringGraphTest()
         {
-            var graph = ParseJsonLdString(@"{
+            var graph = ParseJsonLdGraph(JObject.Parse( @"{
                 ""@graph"": [
                     {
                         ""@id"": ""sor:Row1"",
@@ -495,7 +522,7 @@ namespace VersionedObject.Tests
                     ""sor"": ""http://rdf.equinor.com/ontology/sor#"",
                     ""@version"": ""1.1""
                 }
-            }");
+            }"));
             Assert.NotNull(graph);
             Assert.False(graph.IsEmpty);
         }
@@ -503,7 +530,7 @@ namespace VersionedObject.Tests
         [Fact()]
         public void LoadMarkusGraphTest()
         {
-            var graph = ParseJsonLdString(@"{
+            var graph = ParseJsonLdGraph(JObject.Parse(@"{
                 ""@graph"":[
                     {
                         ""@id"": ""https://example.com/yo"",
@@ -514,7 +541,7 @@ namespace VersionedObject.Tests
                 ""@context"": {
                     ""@version"": ""1.1""
                 }
-            }");
+            }"));
             Assert.NotNull(graph);
             Assert.False(graph.IsEmpty);
         }

--- a/TestVersionedObject/VersionedObjectTests.cs
+++ b/TestVersionedObject/VersionedObjectTests.cs
@@ -13,39 +13,19 @@ namespace VersionedObject.Tests
 {
     public class VersionedObjectTests
     {
-
-
-        public VersionedObjectTests()
-        {
-            var object1 = new
+        
+        public static JObject row1_maker(string? id = "sor:Row1", string? type = "MelRow", string? label = "An empty MEL Row") =>
+            new JObject()
             {
-                id = "sow:Row1",
-                type = "MelRow",
-                label = "A different MEL Row"
+                ["@id"] = id,
+                ["@type"] = type,
+                ["rdfs:label"] = label
             };
-        }
 
-        public static readonly JObject row1 = new JObject()
-        {
-            ["@id"] = "sor:Row1",
-            ["@type"] = "MelRow",
-            ["rdfs:label"] = "An empty MEL Row"
-        };
-
-        public static readonly JObject different_row1 = new()
-        {
-            ["@id"] = "sor:Row1",
-            ["@type"] = "MelRow",
-            ["rdfs:label"] = "A different MEL Row"
-        };
-
-        public static readonly JObject row2 = new()
-        {
-            ["@id"] = "sor:Row2",
-            ["@type"] = "MelRow",
-            ["rdfs:label"] = "The second MEL Row"
-        };
-
+        public static readonly JObject row1 = row1_maker();
+        public static readonly JObject different_row1 = row1_maker(label: "A different MEL Row");
+        public static readonly JObject row2 = row1_maker(id: "sor:Row2", label: "The second MEL Row");
+    
         public static readonly JObject context = new()
         {
             ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",
@@ -133,69 +113,14 @@ namespace VersionedObject.Tests
 
         public static readonly JObject BlankNodeJsonLd3 = new()
         {
-            ["@graph"] = new JArray() { 
-                new JObject()
-                {
-                    ["@id"] = "sor:Row1",
-                    ["@type"] = "MelRow",
-                    ["rdfs:label"] = "An empty MEL Row",
-                    ["http://rds.posccaesar.org/ontology/lis14/rdl/hasPhysicalQuantity"] = new JObject()
-                    {
-                        ["@type"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003589",
-                        ["@id"] = "_:1",
-                        ["rdfs:label"] = "Weight of object",
-                        ["http://rds.posccaesar.org/ontology/lis14/rdl/qualityQuantifiedAs"] = new JObject()
-                        {
-                            ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
-                            ["@id"] = "_:2",
-                            ["rdfs:label"] = "Weight specified",
-                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "12346",
-                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
-                        }
-                    }
-                }
-            },
-            ["@context"] = new JObject()
-            {
-                ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",
-                ["@vocab"] = "http://rdf.equinor.com/ontology/mel#",
-                ["sor"] = "http://rdf.equinor.com/ontology/sor#",
-                ["@version"] = "1.1"
-            }
+            ["@graph"] = new JArray() { GetRow1WithWeights(GetWeightQualityObject(new JArray(){ GetWeightDatumObject(12346) }, "_:1")) },
+            ["@context"] = context
         };
 
         public static readonly JObject BlankNodeJsonLd4 = new()
         {
-            ["@graph"] = new JArray()
-            {
-                new JObject()
-                {
-                    ["@id"] = "sor:Row1",
-                    ["@type"] = "MelRow",
-                    ["rdfs:label"] = "An empty MEL Row",
-                    ["http://rds.posccaesar.org/ontology/lis14/rdl/hasPhysicalQuantity"] = new JObject()
-                    {
-                        ["@type"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003589",
-                        ["@id"] = "_:strangelongblankid",
-                        ["rdfs:label"] = "Weight of object",
-                        ["http://rds.posccaesar.org/ontology/lis14/rdl/qualityQuantifiedAs"] = new JObject()
-                        {
-                            ["@type"] = new JArray("http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003620", "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100004048"),
-                            ["@id"] = "_:evenweirderlongblankid",
-                            ["rdfs:label"] = "Weight specified",
-                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumValue"] = "12346",
-                            ["http://rds.posccaesar.org/ontology/lis14/rdl/datumUOM"] = "http://rds.posccaesar.org/ontology/plm/rdl/PCA_100003684"
-                        }
-                    }
-                }
-            },
-            ["@context"] = new JObject()
-            {
-                ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",
-                ["@vocab"] = "http://rdf.equinor.com/ontology/mel#",
-                ["sor"] = "http://rdf.equinor.com/ontology/sor#",
-                ["@version"] = "1.1"
-            }
+            ["@graph"] = new JArray(){ GetRow1WithWeights(GetWeightQualityObject(new JArray(GetWeightDatumObject(12346, "_:evenweirderlongblankid")){}, "_:strangelongblankid"))},
+            ["@context"] = context
         };
 
         public static readonly JObject aspect_jsonld = new()
@@ -210,32 +135,19 @@ namespace VersionedObject.Tests
                         [VersionedObject.ProvWasDerivedFrom] = VersionedObject.NoProvenance.ToString()
                     }
                 },
-            ["@context"] = new JObject()
-            {
-                ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",
-                ["@vocab"] = "http://rdf.equinor.com/ontology/mel#",
-                ["sor"] = "http://rdf.equinor.com/ontology/sor#",
-                ["@version"] = "1.1"
-            }
+            ["@context"] = context
         };
         public static readonly JObject aspect_persistent_jsonld = new()
         {
             ["@graph"] = new JArray()
-                {
-                    new JObject()
+                { new JObject()
                     {
                         ["@id"] = "sor:Row1",
                         ["@type"] = new JArray(){ "http://rdf.equinor.com/ontology/mel#MelRow" },
                         ["rdfs:label"] = "An empty MEL Row"
                     }
                 },
-            ["@context"] = new JObject()
-            {
-                ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",
-                ["@vocab"] = "http://rdf.equinor.com/ontology/mel#",
-                ["sor"] = "http://rdf.equinor.com/ontology/sor#",
-                ["@version"] = "1.1"
-            }
+            ["@context"] = context
         };
         public static readonly JObject expanded_jsonld = new()
         {
@@ -249,13 +161,7 @@ namespace VersionedObject.Tests
                         ["http://www.w3.org/ns/prov#wasDerivedFrom"] = VersionedObject.NoProvenance.ToString()
                     }
                 },
-            ["@context"] = new JObject()
-            {
-                ["rdfs"] = "http://www.w3.org/2000/01/rdf-schema#",
-                ["@vocab"] = "http://rdf.equinor.com/ontology/mel#",
-                ["sor"] = "http://rdf.equinor.com/ontology/sor#",
-                ["@version"] = "1.1"
-            }
+            ["@context"] = context
         };
 
         [Fact()]

--- a/TestVersionedObject/VersionedObjectTests.cs
+++ b/TestVersionedObject/VersionedObjectTests.cs
@@ -500,8 +500,8 @@ namespace VersionedObject.Tests
         [Fact]
         public void TestMinorReordering()
         {
-            var hash1 = ParseJsonLdString(ReorderTest1.ToString()).GetHash();
-            var hash2 = ParseJsonLdString(ReorderTest2.ToString()).GetHash();
+            var hash1 = ReorderTest1.GetInputGraphAsEntities().First().GetHash();
+            var hash2 = ReorderTest2.GetInputGraphAsEntities().First().GetHash();
             Assert.NotEqual(hash1, hash2);
         }
 

--- a/VersionedObject/JsonLdHelper.cs
+++ b/VersionedObject/JsonLdHelper.cs
@@ -161,10 +161,10 @@ namespace VersionedObject
                 obj.ReplaceIdValue(BlankNodeMarker).GetHash()
                 );
 
-        public static byte[] GetHash(this JObject obj)
+        public static byte[] GetHash(this JObject orig)
         {
-            obj.HashBlankNodes();
-            var g = ParseJsonLdString(obj.ToString());
+            var hashed = orig.HashBlankNodes();
+            var g = ParseJsonLdString(orig.ToString());
 
             var writer = new NTriplesWriter();
             var graphString = VDS.RDF.Writing.StringWriter.Write(g, writer);

--- a/VersionedObject/JsonLdHelper.cs
+++ b/VersionedObject/JsonLdHelper.cs
@@ -85,7 +85,7 @@ namespace VersionedObject
         /// Removes the version suffix from all persistent URIs in the JObject
         /// </summary>
         public static JObject RemoveVersionsFromIris(this JObject versionedEntity, ImmutableHashSet<IRIReference> dict) =>
-            ChangeValuesInObject(x=>x, RemoveVersionFromValue(dict))(versionedEntity);
+            ChangeValuesInObject(x => x, RemoveVersionFromValue(dict))(versionedEntity);
 
         /// <summary>
         /// Helper functions for removeing versions from objects
@@ -137,7 +137,7 @@ namespace VersionedObject
 
         public static JObject AddBlankNodeId(JObject orig) =>
             orig.IsBlankNode() ? orig.ReplaceIdValue(new IRIReference($"{BlankNodeMarker}#{orig.HashWithoutId()}")) : orig;
-        
+
         public static bool IsBlankNode(this JObject orig) =>
             orig.SelectToken("@id") switch
             {
@@ -177,7 +177,7 @@ namespace VersionedObject
 
         public static string HashWithoutId(this JObject obj) =>
             string.Join(
-                "", 
+                "",
                 obj.ReplaceIdValue(BlankNodeMarker).GetHash()
                 );
 
@@ -217,7 +217,7 @@ namespace VersionedObject
         /// <summary>
         /// Parses a string describing a json-ld graph into dotnet IGraph
         /// </summary>
-         public static IGraph ParseJsonLdGraph(JObject jsonLdGraph)
+        public static IGraph ParseJsonLdGraph(JObject jsonLdGraph)
         {
             var parser = new VDS.RDF.Parsing.JsonLdParser();
             using var store = new TripleStore();

--- a/VersionedObject/JsonLdHelper.cs
+++ b/VersionedObject/JsonLdHelper.cs
@@ -73,7 +73,7 @@ namespace VersionedObject
                     .Properties()
                     .Select(ChangeValuesInProperty(valueChanger)));
 
-
+        //select: Func<Func<I,O>, Func<IEnumerable<I>,IEnumerable<O>> 
         /// <summary>
         /// Removes the version suffix from all persistent URIs in the JObject
         /// </summary>


### PR DESCRIPTION
Implementation of task 76712 handle blank nodes

Created tests for variations of blank nodes inside a PersistentObjectData. The tests showed a collision on some common documents. 

The new implementation of hashing does a manipulation of the blank nodes before hashin: 
It replaces the id of any blank node in the following way (working bottom-up /depth first):
The object with blank node (including sub-objects) is hashed but with the top-level id (the blank node) replaced with "https://github.com/equinor/versioned-object/blob/develop/VersionedObject/docs/blanknode.md"
The result of this hashing is added after the top-level id, with the result
"https://github.com/equinor/versioned-object/blob/develop/VersionedObject/docs/blanknode.md#<hash>"

This replacement is not done on the resulting data, only to calculate the hash.